### PR TITLE
#39 レイアウト修正、長い文字列の表示対応

### DIFF
--- a/src/components/ShowComment.tsx
+++ b/src/components/ShowComment.tsx
@@ -8,16 +8,16 @@ const ShowComment: React.FC<ShowCommentProps> = ({name, date, content}) => {
   return (
     <div>
       <div className=
-        "border border-black rounded-t-lg bg-[#25855A] text-white w-[480px] h-[28px] flex"
+        "border border-black rounded-t-lg bg-[#25855A] text-white w-[480px] min-h-[28px] flex"
       >
         {/* コメント投稿したユーザ名と作成日を取得 */}
-        <p className="pl-5">{name}</p>
+        <p className="pl-5 w-[300px] break-words">{name}</p>
         <p className="ml-auto pr-5">{date}</p>
       </div>
       <div className=
         "border-x border-b border-black rounded-b-lg mb-4 w-[480px] min-h-[61px]"
       >
-        <p className="px-3">{content}</p>
+        <p className="px-3 break-words">{content}</p>
       </div>
     </div>
   )

--- a/src/components/ShowTodo.tsx
+++ b/src/components/ShowTodo.tsx
@@ -42,12 +42,12 @@ const ShowTodo: React.FC<TodoShowProps> = (props) => {
       <div className="p-3">
         <p className="bg-[#68D391] text-[24px]">TITLE</p>
         {/* TODOのタイトルを取ってくる */}
-        <p className="text-xl">{title}</p>
+        <p className="text-xl break-words">{title}</p>
       </div>
       <div className="p-3 min-h-[310px]">
         <p className="bg-[#68D391] text-[24px]">DETAIL</p>
         {/* TODOのディティールを取ってくる */}
-        <p className="text-xl">{detail}</p>
+        <p className="text-xl break-words">{detail}</p>
       </div>
       <div className="m-3 flex justify-between">
         <button
@@ -56,8 +56,8 @@ const ShowTodo: React.FC<TodoShowProps> = (props) => {
         >
           <span className="text-[18px] pr-[11px]">Edit</span>
             <svg className="h-5 w-5 text-black mt-1"  fill="none" viewBox="0 0 24 24" stroke="currentColor">
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L6.5 21.036H3v-3.572L16.732 3.732z"/>
-          </svg>
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L6.5 21.036H3v-3.572L16.732 3.732z"/>
+            </svg>
         </button>
           <div className="colums-1 mr-5">
             <p className="text-md">Create</p>

--- a/src/components/commonParts/ButtonClass.tsx
+++ b/src/components/commonParts/ButtonClass.tsx
@@ -6,11 +6,11 @@ const lightpinkButton =
   "bg-[#FED7E2] text-black text-[18px] w-28 h-10 border border-black rounded-3xl mr-2 flex justify-center items-center";
 
 const statusNotStarted =
-  "bg-[#F0FFF4] text-black text-[12px]  w-28 h-10 border border-black rounded-3xl mr-2 flex justify-center items-center";
+  "bg-[#F0FFF4] text-black text-[12px]  w-28 h-10 border border-black rounded-3xl mx-auto flex justify-center items-center";
 const statusDoing =
-  "bg-[#25855A] text-white text-[18px] w-28 h-10 border border-black rounded-3xl mr-2 flex justify-center items-center";
+  "bg-[#25855A] text-white text-[18px] w-28 h-10 border border-black rounded-3xl mx-auto flex justify-center items-center";
 const statusDone =
-  "bg-[#68D391] text-black text-[18px] w-28 h-10 border border-black rounded-3xl mr-2 flex justify-center items-center";
+  "bg-[#68D391] text-black text-[18px] w-28 h-10 border border-black rounded-3xl mx-auto flex justify-center items-center";
 
 export {
   deepGreenButton,


### PR DESCRIPTION
#39 close

機能面のコードの変更はありません。
・ButtonClass.tsx　ステータス部分のレイアウトだけ左に寄っていたため修正。
・ShowTodo.tsx、ShowComment.tsx　画面幅を超える文字列を折り返して表示できるように変更。